### PR TITLE
Added support for square filters.

### DIFF
--- a/AMAT.m
+++ b/AMAT.m
@@ -7,12 +7,14 @@ classdef AMAT < handle
         ws      = 1e-4      
         vistop  = 0  
         shape   = 'disk'
+        rotations = [22.5, 45, 67.5]
         filters 
         input
         reconstruction
         encoding
         axis
         radius
+        shapeId
         depth
         price
         cost
@@ -263,6 +265,8 @@ classdef AMAT < handle
                     computeDiskEncodings(mat);
                 case 'square'
                     computeSquareEncodings(mat);
+                case 'mixed'
+                    computeMixedEncodings(mat);
                 otherwise, error('Invalid shape')
             end            
         end
@@ -273,6 +277,8 @@ classdef AMAT < handle
                     computeDiskCosts(mat);
                 case 'square'
                     computeSquareCosts(mat);
+                case 'mixed'
+                    computeMixedCosts(mat);
                 otherwise, error('Invalid shape')
             end
         end
@@ -293,12 +299,13 @@ classdef AMAT < handle
             %       queue, to avoid min(diskCostEffective(:)) in each iteration?
             
             % Initializations
-            [H,W,C,R]          = size(mat.encoding);
+            [H,W,C,R,S]          = size(mat.encoding);
             zeroLabNormalized  = rgb2labNormalized(zeros(H,W,C));
             mat.input          = reshape(mat.input, H*W, C);
             mat.reconstruction = reshape(zeroLabNormalized,H*W,C);
             mat.axis           = zeroLabNormalized;
             mat.radius         = zeros(H,W);
+            mat.shapeId        = zeros(H,W);
             mat.depth          = zeros(H,W); % #disks points(x,y) is covered by
             mat.price          = zeros(H,W); % error contributed by each point
             % Flag border pixels that cannot be accessed by filters.
@@ -311,10 +318,10 @@ classdef AMAT < handle
             end
             BIG = 1e30;
             
-            % Compute how many pixels are covered be each r-disk.
-            diskAreas = cellfun(@nnz,mat.filters);
+            % Compute how many pixels are covered be each shape.
+            areas = cellfun(@nnz,mat.filters);
             diskCost  = mat.cost;
-            numNewPixelsCovered = repmat(reshape(diskAreas,1,1,[]), [H,W]);
+            numNewPixelsCovered = repmat(reshape(areas',1,1,[],S), [H,W]);
             
             % Add scale-dependent cost term to favor the selection of larger disks.
             costPerPixel = diskCost ./ numNewPixelsCovered;
@@ -325,7 +332,6 @@ classdef AMAT < handle
             printBreakPoints = floor((4:-1:1).*(H*W/5));
             
             fprintf('Pixels remaining: ');
-            [x,y] = meshgrid(1:W,1:H);
             while ~all(covered(:))
                 % Find the most cost-effective disk at the current iteration
                 [minCost, indMin] = min(diskCostEffective(:));
@@ -334,14 +340,10 @@ classdef AMAT < handle
                     break;
                 end
                 
-                [yc,xc,rc] = ind2sub([H,W,R], indMin);
-                switch mat.shape
-                    case 'disk'
-                        D = (x-xc).^2 + (y-yc).^2 <= mat.scales(rc)^2; % points covered by the selected disk
-                    case 'square'
-                        D = (abs(x-xc) <= mat.scales(rc)) & (abs(y-yc) <= mat.scales(rc));
-                    otherwise, error('Invalid filter shape')
-                end
+                [yc,xc,rc,sc] = ind2sub([H,W,R,S], indMin);
+
+                % points covered by the selected shape
+                D = logical(addMask(zeros(H,W),yc,xc,mat.filters{sc,rc}));
                 
                 newPixelsCovered  = D & ~covered;      % NEW pixels that are covered by D
                 if ~any(newPixelsCovered(:))
@@ -356,28 +358,37 @@ classdef AMAT < handle
                 xmin = min(xx); xmax = max(xx);
                 ymin = min(yy); ymax = max(yy);
                 newPixelsCovered = double(newPixelsCovered);
-                for r=1:R
-                    scale = mat.scales(r);
-                    x1 = max(xmin-scale,1); y1 = max(ymin-scale,1);
-                    x2 = min(xmax+scale,W); y2 = min(ymax+scale,H);
-                    % Find how many of the newPixelsCovered are covered by other disks.
-                    numPixelsSubtracted = ...
-                        conv2(newPixelsCovered(y1:y2,x1:x2), mat.filters{r},'same');
-                    % and subtract the respective counts from those disks.
-                    numNewPixelsCovered(y1:y2,x1:x2, r) = ...
-                        numNewPixelsCovered(y1:y2,x1:x2, r) - numPixelsSubtracted;
-                    % update diskCost, costPerPixel, and diskCostEfficiency *only* for
-                    % the locations that have been affected, for efficiency.
-                    diskCost(y1:y2,x1:x2, r) = diskCost(y1:y2,x1:x2, r) - ...
-                        numPixelsSubtracted .* costPerPixel(y1:y2,x1:x2, r);
-                    costPerPixel(y1:y2,x1:x2, r) = diskCost(y1:y2,x1:x2, r) ./ ...
-                        max(eps,numNewPixelsCovered(y1:y2,x1:x2, r)) + ... % avoid 0/0
-                        BIG*(numNewPixelsCovered(y1:y2,x1:x2, r) == 0);    % x/0 = inf
-                    diskCostEffective(y1:y2,x1:x2, r) = ...
-                        costPerPixel(y1:y2,x1:x2, r) + mat.ws/mat.scales(r);
+                
+                if (strcmp(mat.shape, 'mixed'))
+                    numShapes = 2 + numel(mat.rotations);
+                else
+                    numShapes = 1;
+                end
+                
+                for d=1:numShapes
+                    for r=1:R
+                        scale = mat.scales(r);
+                        x1 = max(xmin-scale,1); y1 = max(ymin-scale,1);
+                        x2 = min(xmax+scale,W); y2 = min(ymax+scale,H);
+                        % Find how many of the newPixelsCovered are covered by other disks.
+                        numPixelsSubtracted = ...
+                            conv2(newPixelsCovered(y1:y2,x1:x2), mat.filters{d,r},'same');
+                        % and subtract the respective counts from those disks.
+                        numNewPixelsCovered(y1:y2,x1:x2, r, d) = ...
+                            numNewPixelsCovered(y1:y2,x1:x2, r, d) - numPixelsSubtracted;
+                        % update diskCost, costPerPixel, and diskCostEfficiency *only* for
+                        % the locations that have been affected, for efficiency.
+                        diskCost(y1:y2,x1:x2, r, d) = diskCost(y1:y2,x1:x2, r, d) - ...
+                            numPixelsSubtracted .* costPerPixel(y1:y2,x1:x2, r, d);
+                        costPerPixel(y1:y2,x1:x2, r, d) = diskCost(y1:y2,x1:x2, r, d) ./ ...
+                            max(eps,numNewPixelsCovered(y1:y2,x1:x2, r, d)) + ... % avoid 0/0
+                            BIG*(numNewPixelsCovered(y1:y2,x1:x2, r, d) == 0);    % x/0 = inf
+                        diskCostEffective(y1:y2,x1:x2, r, d) = ...
+                            costPerPixel(y1:y2,x1:x2, r, d) + mat.ws/mat.scales(r);
+                    end
                 end
                 % Make sure the same point is not selected again
-                diskCost(yc,xc,:) = BIG; diskCostEffective(yc,xc,:) = BIG;
+                diskCost(yc,xc,:,:) = BIG; diskCostEffective(yc,xc,:,:) = BIG;
                 
                 if mat.vistop, visualizeProgress(mat,diskCostEffective); end
                 if ~isempty(printBreakPoints) && nnz(~covered) < printBreakPoints(1)
@@ -392,10 +403,11 @@ classdef AMAT < handle
             
             function update(mat)
                 covered(newPixelsCovered) = true;
-                mat.price(newPixelsCovered) = minCost / numNewPixelsCovered(yc,xc,rc);
+                mat.price(newPixelsCovered) = minCost / numNewPixelsCovered(yc,xc,rc,sc);
                 mat.depth(D) = mat.depth(D) + 1;
-                mat.axis(yc,xc,:) = mat.encoding(yc,xc,:,rc);
+                mat.axis(yc,xc,:) = mat.encoding(yc,xc,:,rc,sc);
                 mat.radius(yc,xc) = mat.scales(rc);    
+                mat.shapeId(yc,xc) = sc;
             end
             function visualizeProgress(mat,diskCost)
                 % Sort costs in ascending order to visualize updated top disks.
@@ -442,7 +454,12 @@ classdef AMAT < handle
         end
         
         function rec = computeReconstruction(mat)
-            diskf = cell(1,numel(mat.scales));
+            if (strcmp(mat.shape, 'mixed'))
+                diskf = cell(2+numel(mat.rotations),numel(mat.scales));
+            else
+                diskf = cell(1,numel(mat.scales));
+            end
+            
             for r=1:numel(diskf)
                 diskf{r} = double(repmat(mat.filters{r}, [1 1 3]));
             end
@@ -453,8 +470,8 @@ classdef AMAT < handle
                 x = xc(p); y = yc(p); 
                 r = round(mat.radius(y,x)); 
                 c = mat.axis(y,x,:);
-                rec((y-r):(y+r),(x-r):(x+r),:) = ...
-                    rec((y-r):(y+r),(x-r):(x+r),:) + bsxfun(@times, diskf{mat.scaleIdx(r)}, c);
+                s = mat.shapeId(y,x);
+                rec = addMask(rec, y, x, bsxfun(@times, diskf{s, mat.scaleIdx(r)}, c));
             end
             rec = bsxfun(@rdivide, rec, mat.depth);
             % Sometimes not all pixels are covered (e.g. at image corners
@@ -560,11 +577,37 @@ classdef AMAT < handle
             mat.shape   = opts('shape');
             mat.input   = im2double(img);
             mat.scaleIdx= containers.Map(mat.scales, 1:numel(mat.scales));
-            mat.initializeFilters();            
+            mat.initializeFilters();
         end
         
         function initializeFilters(mat)
             numScales = numel(mat.scales);
+            
+            if (strcmp(mat.shape, 'mixed'))
+                degrees = mat.rotations;
+                numShapes = 2 + numel(degrees);
+                mat.filters = cell(numShapes, numScales);
+                
+                % disks
+                for i=1:numScales
+                    mat.filters{1,i} = double(disk(mat.scales(i)));
+                end
+                
+                % squares without rotation
+                for i=1:numScales
+                    mat.filters{2,i} = double(ones(2*mat.scales(i)+1));
+                end
+                
+                % squares with rotations
+                for d=1:numel(degrees)
+                    for i=1:numScales
+                        rotatedFilter = imrotate(ones(2*mat.scales(i)+1),degrees(d));
+                        mat.filters{d+2,i} = double(padarray(rotatedFilter, double(mod(size(rotatedFilter), 2) == 0), 'pre'));
+                    end
+                end
+                return
+            end
+            
             mat.filters = cell(1, numScales);
             switch mat.shape
                 case 'disk'
@@ -737,6 +780,110 @@ classdef AMAT < handle
             mat.cost = squareCost;
         end
         
+        function computeMixedEncodings(mat)
+             % convert RGB to Lab
+            inputlab = rgb2labNormalized(mat.input);
+            
+            % Compute the integral column of input.
+            inputIntegralColumn = cumsum(inputlab, 1);
+            
+            [H,W,C] = size(mat.input);
+            R = numel(mat.scales);
+            
+            degrees = mat.rotations;
+            enc = zeros(H,W,C,R,2+numel(degrees));
+            
+            mat.computeDiskEncodings();
+            enc(:,:,:,:,1) = mat.encoding;
+            
+            mat.computeSquareEncodings();
+            enc(:,:,:,:,2) = mat.encoding;
+            
+            for d=1:numel(degrees)
+                for i=1:R
+                    r = mat.scales(i);
+                    encTemp = computeRotatedSquareSums(inputIntegralColumn, r, degrees(d));
+                    enc(:,:,:,i,d+2) = encTemp ./ squareAreas(H, W, r, degrees(d));
+                end
+            end
+            mat.encoding = enc;
+        end
+        
+        function computeMixedCosts(mat)
+            enc = mat.encoding;
+            [H,W,~,R,S] = size(enc);
+            mixedCost = zeros(H,W,R,S);
+            
+            % disk costs
+            mat.encoding = enc(:,:,:,:,1);
+            mat.computeDiskCosts();
+            mixedCost(:,:,:,1) = mat.cost;
+            
+            % square costs without rotations
+            mat.encoding = enc(:,:,:,:,2);
+            mat.computeSquareCosts();
+            mixedCost(:,:,:,2) = mat.cost;
+            
+            mat.encoding = enc;
+            
+            degrees = mat.rotations;
+            
+            for d=1:numel(degrees)
+                % compute the square costs
+                
+                enc = mat.encoding(:,:,:,:,d+2);
+                [H,W,C,R] = size(enc);
+                enc2 = enc .^ 2;
+                squareCost = zeros(H,W,C,R);
+                
+                % heuristic square cost approach
+                % integral images
+                encIntegralColumn = cumsum(enc,1);
+                enc2IntegralColumn = cumsum(enc2,1);
+                cfilt = cell(1,R);
+                for r=1:R
+                    cfilt{r} = imrotate(ones(2*(mat.scales(r)-1)+1), degrees(d));
+                end
+                nnzcs = cumsum(cellfun(@nnz, cfilt));
+                for r=1:R
+                    sumMri = zeros(H,W,C);
+                    sumMri2 = zeros(H,W,C);
+                    for i=1:r
+                        sumMri = sumMri + computeRotatedSquareSums(encIntegralColumn(:,:,:,i), mat.scales(r-i+1)-1, degrees(d));
+                        sumMri2 = sumMri2 + computeRotatedSquareSums(enc2IntegralColumn(:,:,:,i), mat.scales(r-i+1)-1, degrees(d));
+                    end
+                    squareCost(:,:,:,r) = enc2(:,:,:,r)*nnzcs(r) + sumMri2 - 2*enc(:,:,:,r).*sumMri;
+                end
+                
+                % Same postprocesssing as computeDiskCosts
+                
+                % Fix boundary conditions. Setting scale(r)-borders to a very big cost
+                % helps us avoid selecting disks that cross the image boundaries.
+                % We do not use Inf to avoid complications in the greedy set cover
+                % algorithm, caused by inf-inf subtractions and inf/inf divisions.
+                % Also, keep in mind that max(0,NaN) = 0.
+                BIG = 1e30;
+                for r=1:R
+                    scale = mat.scales(r);
+                    scale = ceil(2 * scale);
+                    squareCost([1:scale, end-scale+1:end],:,:,r) = BIG;
+                    squareCost(:,[1:scale, end-scale+1:end],:,r) = BIG;
+                end
+                
+                % Sometimes due to numerical errors, cost are slightly negative. Fix this.
+                squareCost = max(0,squareCost);
+                
+                % Combine costs from different channels
+                if C > 1
+                    wc = [0.5,0.25,0.25]; % weights for luminance and color channels
+                    squareCost = squareCost(:,:,1,:)*wc(1) + squareCost(:,:,2,:)*wc(2) + squareCost(:,:,3,:)*wc(3);
+                end
+                squareCost = squeeze(squareCost);
+                mixedCost(:,:,:,d+2) = squareCost;
+            end
+            
+            mat.cost = mixedCost;
+        end
     end
     
 end

--- a/AMAT.m
+++ b/AMAT.m
@@ -696,29 +696,19 @@ classdef AMAT < handle
             enc2 = enc .^ 2;
             squareCost = zeros(H,W,C,R);
             
-%             % heuristic square cost approach
-%             % integral images
-%             encIntegral = integralImage(enc);
-%             enc2Integral = integralImage(enc2);
-%             nnzcs = cumsum((2*(mat.scales-1)+1).^2);
-%             
-%             for r=1:R
-%                 sumMri = zeros(H,W,C);
-%                 sumMri2 = zeros(H,W,C);
-%                 for i=1:r
-%                     sumMri = sumMri + computeSquareSumsConv(encIntegral(:,:,:,i), mat.scales(r-i+1) - 1);
-%                     sumMri2 = sumMri2 + computeSquareSumsConv(enc2Integral(:,:,:,i), mat.scales(r-i+1) - 1);
-%                 end
-%                 squareCost(:,:,:,r) = enc2(:,:,:,r)*nnzcs(r) + sumMri2 - 2*enc(:,:,:,r).*sumMri;
-%             end
-            
-            % mean square error implementation.
-            input2 = rgb2labNormalized(mat.input) .^2;
-            input2Integral = integralImage(input2);
-            for i=1:R
-                r = mat.scales(i);
-                squareCost(:, :, :, i) = computeSquareSumsConv(input2Integral, r) ...
-                    - enc2(:, :, :, i) .* (2*r+1)^2;
+            % heuristic square cost approach
+            % integral images
+            encIntegral = integralImage(enc);
+            enc2Integral = integralImage(enc2);
+            nnzcs = cumsum((2*(mat.scales-1)+1).^2);
+            for r=1:R
+                sumMri = zeros(H,W,C);
+                sumMri2 = zeros(H,W,C);
+                for i=1:r
+                    sumMri = sumMri + computeSquareSumsConv(encIntegral(:,:,:,i), mat.scales(r-i+1) - 1);
+                    sumMri2 = sumMri2 + computeSquareSumsConv(enc2Integral(:,:,:,i), mat.scales(r-i+1) - 1);
+                end
+                squareCost(:,:,:,r) = enc2(:,:,:,r)*nnzcs(r) + sumMri2 - 2*enc(:,:,:,r).*sumMri;
             end
 
             % Same postprocesssing as computeDiskCosts
@@ -742,8 +732,8 @@ classdef AMAT < handle
             if C > 1
                 wc = [0.5,0.25,0.25]; % weights for luminance and color channels
                 squareCost = squareCost(:,:,1,:)*wc(1) + squareCost(:,:,2,:)*wc(2) + squareCost(:,:,3,:)*wc(3);
-                squareCost = squeeze(squareCost);
             end
+            squareCost = squeeze(squareCost);
             mat.cost = squareCost;
         end
         

--- a/AMAT.m
+++ b/AMAT.m
@@ -368,6 +368,7 @@ classdef AMAT < handle
                 for d=1:numShapes
                     for r=1:R
                         scale = mat.scales(r);
+                        scale = ceil(sqrt(2) * scale);
                         x1 = max(xmin-scale,1); y1 = max(ymin-scale,1);
                         x2 = min(xmax+scale,W); y2 = min(ymax+scale,H);
                         % Find how many of the newPixelsCovered are covered by other disks.
@@ -865,7 +866,7 @@ classdef AMAT < handle
                 BIG = 1e30;
                 for r=1:R
                     scale = mat.scales(r);
-                    scale = ceil(2 * scale);
+                    scale = ceil(sqrt(2) * scale);
                     squareCost([1:scale, end-scale+1:end],:,:,r) = BIG;
                     squareCost(:,[1:scale, end-scale+1:end],:,r) = BIG;
                 end

--- a/addMask.m
+++ b/addMask.m
@@ -1,0 +1,38 @@
+function out = addMask(I, y, x, msk)
+% Add msk to image I centered at y,x
+
+[H,W,~] = size(I);
+
+% make sure fil has a center
+msk = padarray(msk, double(mod(size(msk), 2) == 0), 'pre');
+
+[ry,rx,~] = size(msk);
+ry = floor(ry / 2);
+rx = floor(rx / 2);
+
+% Since we are using convolution, the image should be rotated by 180 deg.
+msk = imrotate(msk,180);
+
+y1 = y - ry; y2 = y + ry; x1 = x - rx; x2 = x + rx;
+
+if (y-ry < 1)
+    msk = msk(2+ry-y:end,:,:);
+    y1 = 1;
+end
+if (x-rx < 1)
+    msk = msk(:,2+rx-x:end,:);
+    x1 = 1;
+end
+if (y+ry > H)
+    msk = msk(1:end-(y+ry-H),:,:);
+    y2 = H;
+end
+if (x+rx > W)
+    msk = msk(:,1:end-(x+rx-W),:);
+    x2 = W;
+end
+
+I(y1:y2,x1:x2,:) = I(y1:y2,x1:x2,:) + msk;
+out = I;
+
+end

--- a/computeRotatedSquareSums.m
+++ b/computeRotatedSquareSums.m
@@ -1,0 +1,29 @@
+function rotatedSqrSum = computeRotatedSquareSums(integralColumn, radius, deg)
+%COMPUTEROTATEDSQUARESUMS Summary of this function goes here
+%   Detailed explanation goes here
+% if the image is I, then integralColumn should be cumsum(I, 1)
+
+[H,W,C] = size(integralColumn);
+
+filter = ones(2*radius+1);
+
+% rotated square
+rotatedFilter = imrotate(filter, deg);
+
+% make sure both the width and height of rotatedFilter are odd to make sure
+% it has a center
+rotatedFilter = padarray(rotatedFilter, double(mod(size(rotatedFilter), 2) == 0), 'pre');
+padSize = floor(size(rotatedFilter) / 2);
+
+% pad integralColumn to deal with pixels along the border
+cumA = padarray(padarray(integralColumn, padSize, 'pre'), [padSize(1),0], 'post', 'replicate');
+
+simpleRotatedFilter = getSimpleRotatedFilter(rotatedFilter);
+
+rotatedSqrSum = zeros(H,W,C);
+for c=1:C
+    rotatedSqrSumC = conv2(cumA(:,:,c), simpleRotatedFilter, 'same');
+    % make sure the output size is consistent
+    rotatedSqrSum(:,:,c) = rotatedSqrSumC(padSize(1):end-padSize(1)-1, padSize(2)+1:end);
+end
+end

--- a/computeSquareSumsConv.m
+++ b/computeSquareSumsConv.m
@@ -5,19 +5,22 @@ function out = computeSquareSumsConv(inputIntegral, r)
 %   r: radius
 %   returns the square sums of the square at each pixel with radius r
 
-fil = zeros(2*r+2, 1);
+fil = zeros(2*r+3, 1);
 fil(1) = 1;
-fil(end) = -1;
+fil(end-1) = -1;
 
-[H,W,C] = size(inputIntegral);
+% pad the matrix to handle the border
+paddedArray = padarray(inputIntegral, [r, r], 'replicate', 'post');
+
+[H,W,C] = size(paddedArray);
 out = zeros(H,W,C);
 
 for c=1:C
     % separable filter
-    out(:,:,c) = conv2(conv2(inputIntegral(:,:,c), fil, 'same'), fil', 'same');
+    out(:,:,c) = conv2(conv2(paddedArray(:,:,c), fil, 'same'), fil', 'same');
 end
 
 % make the output the same as input image
-out = out(1:end-1, 1:end-1, :);
+out = out(1:end-1-r, 1:end-1-r, :);
 end
 

--- a/computeSquareSumsConv.m
+++ b/computeSquareSumsConv.m
@@ -1,0 +1,23 @@
+function out = computeSquareSumsConv(inputIntegral, r)
+%COMPUTESQUARESUMSCONV
+%   inputIntegral: the integral image of an input I, geneated by calling
+%                  integralImage(I)
+%   r: radius
+%   returns the square sums of the square at each pixel with radius r
+
+fil = zeros(2*r+2, 1);
+fil(1) = 1;
+fil(end) = -1;
+
+[H,W,C] = size(inputIntegral);
+out = zeros(H,W,C);
+
+for c=1:C
+    % separable filter
+    out(:,:,c) = conv2(conv2(inputIntegral(:,:,c), fil, 'same'), fil', 'same');
+end
+
+% make the output the same as input image
+out = out(1:end-1, 1:end-1, :);
+end
+

--- a/getSimpleRotatedFilter.m
+++ b/getSimpleRotatedFilter.m
@@ -1,0 +1,13 @@
+function simpleRotatedFilter =  getSimpleRotatedFilter(filter)
+[H,W] = size(filter);
+[y,x] = find(filter);
+onesInd = [y,x];
+simpleRotatedFilter = zeros(H+1,W);
+for w=1:W
+    wInd = onesInd(onesInd(:,2) == w);
+    wMin = min(wInd);
+    wMax = max(wInd);
+    simpleRotatedFilter(wMin,w) = 1;
+    simpleRotatedFilter(wMax+1,w) = -1;
+end
+end

--- a/imcropCenter.m
+++ b/imcropCenter.m
@@ -1,0 +1,12 @@
+function out = imcropCenter(A, height, width)
+%IMCROPCENTER crop image A to size height*width
+
+[H,W,~] = size(A);
+if (height > H || width > W)
+    error('height and width must be less than the size of A.')
+end
+pad = [H - height, W - width] / 2;
+out = A(ceil(pad(1))+1:H-floor(pad(1)), ceil(pad(2))+1:W-floor(pad(2)), :);
+
+end
+

--- a/squareAreas.m
+++ b/squareAreas.m
@@ -1,0 +1,7 @@
+function out = squareAreas(H,W,r)
+%SQUAREAREA
+%   returns an HxW matrix that represents how many pixels are covered by a
+%   square with radius r
+out = conv2(ones(H,W), ones(2*r+1), 'same');
+end
+

--- a/squareAreas.m
+++ b/squareAreas.m
@@ -1,7 +1,15 @@
-function out = squareAreas(H,W,r)
+function out = squareAreas(H,W,r,deg)
 %SQUAREAREA
 %   returns an HxW matrix that represents how many pixels are covered by a
 %   square with radius r
-out = conv2(ones(H,W), ones(2*r+1), 'same');
+%   rotation deg
+if nargin < 4
+    deg = 0;
+end
+
+rotatedFilter = imrotate(ones(2*r+1), deg);
+rotatedFilter = padarray(rotatedFilter, double(mod(size(rotatedFilter), 2) == 0), 'pre');
+
+out = conv2(ones(H,W), rotatedFilter, 'same');
 end
 


### PR DESCRIPTION
Use integral image to compute the encodings and costs.

To use the square filters
`google = imresize(imread('google.jpg'),0.5);
mat = AMAT(google, 'shape', 'square');`

Now the costs is using mean square errors.
There is also an implementation for the heuristic costs (Line 699-713) but some issues along the boundaries remains so that part of the code is commented out.

The implementation is ~10s faster than the disk one with mean square errors and ~7s faster with the heuristic costs. However the result is not as good as the disk implementation especially for the reconstruction after grouping and simplifying.

Looked into the computeReconstruction and it is not necessary to change.
